### PR TITLE
[Fix]: block size and valid index size of cuda kernel

### DIFF
--- a/bbs3d/include/gpu_bbs3d/bbs3d.cuh
+++ b/bbs3d/include/gpu_bbs3d/bbs3d.cuh
@@ -73,8 +73,8 @@ public:
     void localize();
 
   private:
-    void trans_search_range();
-    void angluar_search_range(std::vector<AngularInfo>& ang_info_vec);
+    void calc_trans_search_range();
+    void calc_angluar_search_range(std::vector<AngularInfo>& ang_info_vec);
 
     std::vector<DiscreteTransformation> create_init_transset(const AngularInfo& init_ang_info);
 

--- a/bbs3d/src/gpu_bbs3d/bbs3d.cu
+++ b/bbs3d/src/gpu_bbs3d/bbs3d.cu
@@ -26,7 +26,7 @@ void BBS3D::set_tar_points(const std::vector<Eigen::Vector3f>& points, float min
   voxelmaps_ptr_->set_max_level(max_level);
   voxelmaps_ptr_->create_voxelmaps(points, stream);
 
-  trans_search_range();
+  calc_trans_search_range();
 }
 
 void BBS3D::set_src_points(const std::vector<Eigen::Vector3f>& points) {
@@ -47,7 +47,7 @@ void BBS3D::set_src_points(const std::vector<Eigen::Vector3f>& points) {
     stream);
 }
 
-void BBS3D::trans_search_range() {
+void BBS3D::calc_trans_search_range() {
   // Detect translation range from target points
   Eigen::Vector3f min_xyz = Eigen::Vector3f::Constant(std::numeric_limits<float>::max());
   Eigen::Vector3f max_xyz = Eigen::Vector3f::Constant(std::numeric_limits<float>::lowest());
@@ -64,7 +64,7 @@ void BBS3D::trans_search_range() {
   init_tz_range_ = std::make_pair<int, int>(std::floor(min_xyz.z() / top_res), std::ceil(max_xyz.z() / top_res));
 }
 
-void BBS3D::angluar_search_range(std::vector<AngularInfo>& ang_info_vec) {
+void BBS3D::calc_angluar_search_range(std::vector<AngularInfo>& ang_info_vec) {
   float max_norm = src_points_[0].norm();
   for (const auto& point : src_points_) {
     float norm = point.norm();
@@ -154,7 +154,7 @@ void BBS3D::localize() {
   // Preapre initial transset
   const int max_level = voxelmaps_ptr_->get_max_level();
   std::vector<AngularInfo> ang_info_vec(max_level + 1);
-  angluar_search_range(ang_info_vec);
+  calc_angluar_search_range(ang_info_vec);
   const auto init_transset = create_init_transset(ang_info_vec[max_level]);
 
   // Calc initial transset scores

--- a/bbs3d/src/gpu_bbs3d/calc_score.cu
+++ b/bbs3d/src/gpu_bbs3d/calc_score.cu
@@ -7,11 +7,11 @@ __global__ void calc_scores_kernel(
   const thrust::device_ptr<Eigen::Vector4i*> multi_buckets_ptrs,
   const thrust::device_ptr<VoxelMapInfo> voxelmap_info_ptr,
   thrust::device_ptr<DiscreteTransformation> trans_ptr,
-  size_t transset_size,
+  size_t index_size,
   const thrust::device_ptr<Eigen::Vector3f> points_ptr,
   size_t num_points) {
   const size_t pose_index = threadIdx.x + blockIdx.x * blockDim.x;
-  if (pose_index > transset_size) {
+  if (pose_index > index_size) {
     return;
   }
 

--- a/bbs3d/src/gpu_bbs3d/calc_score.cu
+++ b/bbs3d/src/gpu_bbs3d/calc_score.cu
@@ -59,18 +59,14 @@ std::vector<DiscreteTransformation> BBS3D::calc_scores(const std::vector<Discret
     cudaMemcpyHostToDevice,
     stream);
 
-  size_t block_size;
-  if (transset_size > 1024)
-    block_size = 1024;
-  else
-    block_size = transset_size;
+  const size_t block_size = 32;
   const size_t num_blocks = (transset_size + (block_size - 1)) / block_size;
 
   calc_scores_kernel<<<num_blocks, block_size, 0, stream>>>(
     voxelmaps_ptr_->d_multi_buckets_ptrs_.data(),
     voxelmaps_ptr_->d_voxelmaps_info_.data(),
     d_transset.data(),
-    transset_size,
+    transset_size - 1,
     d_src_points_.data(),
     src_size_);
 

--- a/test/include/load.hpp
+++ b/test/include/load.hpp
@@ -18,12 +18,12 @@ Eigen::Vector3d to_eigen(const std::vector<double>& vec) {
 bool BBS3DTest::load_config(const std::string& config) {
   YAML::Node conf = YAML::LoadFile(config);
 
-  std::cout << "[YAML] Loading paths" << std::endl;
+  std::cout << "[YAML] Loading paths..." << std::endl;
   tar_path = conf["target_clouds"].as<std::string>();
   src_path = conf["source_clouds"].as<std::string>();
   output_path = conf["output_folder"].as<std::string>();
 
-  std::cout << "[YAML] Loading 3D-BBS parameters" << std::endl;
+  std::cout << "[YAML] Loading 3D-BBS parameters..." << std::endl;
   min_level_res = conf["min_level_res"].as<double>();
   max_level = conf["max_level"].as<int>();
 
@@ -32,7 +32,7 @@ bool BBS3DTest::load_config(const std::string& config) {
     return false;
   }
 
-  std::cout << "[YAML] Loading angular search range" << std::endl;
+  std::cout << "[YAML] Loading angular search range..." << std::endl;
   std::vector<double> min_rpy_temp = conf["min_rpy"].as<std::vector<double>>();
   std::vector<double> max_rpy_temp = conf["max_rpy"].as<std::vector<double>>();
   if (min_rpy_temp.size() == 3 && max_rpy_temp.size() == 3) {
@@ -43,10 +43,10 @@ bool BBS3DTest::load_config(const std::string& config) {
     return false;
   }
 
-  std::cout << "[YAML] Loading score threshold percentage" << std::endl;
+  std::cout << "[YAML] Loading score threshold percentage..." << std::endl;
   score_threshold_percentage = conf["score_threshold_percentage"].as<double>();
 
-  std::cout << "[YAML] Loading downsample souce clouds parameters" << std::endl;
+  std::cout << "[YAML] Loading downsample souce clouds parameters..." << std::endl;
   valid_tar_vgf = conf["valid_tar_vgf"].as<bool>();
   if (valid_tar_vgf) tar_leaf_size = conf["tar_leaf_size"].as<float>();
 

--- a/test/src/gpu_bbs3d/gpu_test.cu
+++ b/test/src/gpu_bbs3d/gpu_test.cu
@@ -14,29 +14,30 @@ BBS3DTest::~BBS3DTest() {}
 int BBS3DTest::run(std::string config) {
   // Load config file
   if (!load_config(config)) {
-    std::cout << "[ERROR] load config file" << std::endl;
+    std::cout << "[ERROR]  Loading config file failed" << std::endl;
     return 1;
   };
 
   if (use_gicp) gicp_ptr.reset(new GICP);
 
   // Load target pcds
+  std::cout << "[Setting] Loading target pcds..." << std::endl;
   std::vector<Eigen::Vector3f> tar_points;
   if (!load_tar_clouds(tar_points)) {
-    std::cout << "[ERROR] load target clouds" << std::endl;
+    std::cout << "[ERROR] Loading target pcd failed" << std::endl;
     return 1;
   }
 
   // Load source pcds
-  std::cout << "Load source pcds" << std::endl;
+  std::cout << "[Setting] Loading source pcds..." << std::endl;
   std::map<std::string, std::vector<Eigen::Vector3f>> src_points_set;
   if (!load_src_clouds(src_points_set)) {
-    std::cout << "[ERROR] load source clouds" << std::endl;
+    std::cout << "[ERROR] Loading source pcds failed" << std::endl;
     return 1;
   };
 
   // Create output folder with date
-  std::cout << "Create output folder with date" << std::endl;
+  std::cout << "[Setting] Create output folder with date..." << std::endl;
   std::string date = createDate();
   std::string pcd_save_folder_path = output_path + "/" + date;
   boost::filesystem::create_directory(pcd_save_folder_path);
@@ -44,19 +45,20 @@ int BBS3DTest::run(std::string config) {
   // ====3D-BBS====
   // Set target points
   auto initi_t1 = std::chrono::high_resolution_clock::now();
-  std::cout << "Set target points" << std::endl;
+  std::cout << "[Voxel map] creating hierarchical voxel map..." << std::endl;
   std::unique_ptr<gpu::BBS3D> bbs3d_ptr(new gpu::BBS3D);
   bbs3d_ptr->set_tar_points(tar_points, min_level_res, max_level);
   bbs3d_ptr->set_angular_search_range(min_rpy.cast<float>(), max_rpy.cast<float>());
 
   auto init_t2 = std::chrono::high_resolution_clock::now();
   double init_time = std::chrono::duration_cast<std::chrono::nanoseconds>(init_t2 - initi_t1).count() / 1e6;
-  std::cout << "[Hierarchical voxel map creation]Execution time: " << init_time << "[msec] " << std::endl;
+  std::cout << "[Voxel map] Execution time: " << init_time << "[msec] " << std::endl;
 
   int sum_time = 0;
   // localization
   for (const auto& src_points : src_points_set) {
     std::cout << "-------------------------------" << std::endl;
+    std::cout << "[Localize] pcd file name: " << src_points.first << std::endl;
     bbs3d_ptr->set_src_points(src_points.second);
 
     auto localize_t1 = std::chrono::high_resolution_clock::now();
@@ -64,11 +66,11 @@ int BBS3DTest::run(std::string config) {
     bbs3d_ptr->localize();
     auto localize_t2 = std::chrono::high_resolution_clock::now();
     double localize_time = std::chrono::duration_cast<std::chrono::nanoseconds>(localize_t2 - localize_t1).count() / 1e6;
-    std::cout << "[Localize]Execution time: " << localize_time << "[msec] " << std::endl;
-    std::cout << "[Localize]Score: " << bbs3d_ptr->get_best_score() << std::endl;
+    std::cout << "[Localize] Execution time: " << localize_time << "[msec] " << std::endl;
+    std::cout << "[Localize] Score: " << bbs3d_ptr->get_best_score() << std::endl;
 
     if (!bbs3d_ptr->has_localized()) {
-      std::cout << "[Localize]Failed: score is below the threshold." << std::endl;
+      std::cout << "[Failed] Score is below the threshold." << std::endl;
       continue;
     }
 
@@ -86,7 +88,7 @@ int BBS3DTest::run(std::string config) {
     }
     pcl::io::savePCDFileBinary(pcd_save_folder_path + "/" + src_points.first + ".pcd", *output_cloud_ptr);
   }
-  std::cout << "[Localize]Average time: " << sum_time / src_points_set.size() << "[msec] per frame" << std::endl;
+  std::cout << "[Localize] Average time: " << sum_time / src_points_set.size() << "[msec] per frame" << std::endl;
   return 0;
 }
 


### PR DESCRIPTION
I detected an additional bug of cuda illegal access error in calc_scores.

transset_size should be transset_size -1 in the argument of calc_scores_kernel.
Correct line is
```
calc_scores_kernel<<<num_blocks, block_size, 0, stream>>>(
    voxelmaps_ptr_->d_multi_buckets_ptrs_.data(),
    voxelmaps_ptr_->d_voxelmaps_info_.data(),
    d_transset.data(),
    transset_size - 1,
    d_src_points_.data(),
    src_size_);
```

Also, I renamed some function and fixed output statements.