### PR TITLE
Fix: make trans search range configurable

### DIFF
--- a/bbs3d/include/gpu_bbs3d/bbs3d.cuh
+++ b/bbs3d/include/gpu_bbs3d/bbs3d.cuh
@@ -53,7 +53,10 @@ public:
     ~BBS3D();
 
     void set_tar_points(const std::vector<Eigen::Vector3f>& points, float min_level_res, int max_level);
+
     void set_src_points(const std::vector<Eigen::Vector3f>& points);
+
+    void set_trans_search_range(const std::vector<Eigen::Vector3f>& points);
 
     void set_angular_search_range(const Eigen::Vector3f& min_rpy, const Eigen::Vector3f& max_rpy) {
       min_rpy_ = min_rpy;
@@ -73,8 +76,7 @@ public:
     void localize();
 
   private:
-    void calc_trans_search_range();
-    void calc_angluar_search_range(std::vector<AngularInfo>& ang_info_vec);
+    void calc_angluar_info(std::vector<AngularInfo>& ang_info_vec);
 
     std::vector<DiscreteTransformation> create_init_transset(const AngularInfo& init_ang_info);
 

--- a/bbs3d/include/gpu_bbs3d/bbs3d.cuh
+++ b/bbs3d/include/gpu_bbs3d/bbs3d.cuh
@@ -67,6 +67,10 @@ public:
 
     void set_score_threshold_percentage(float percentage) { score_threshold_percentage_ = percentage; }
 
+    std::vector<Eigen::Vector3f> get_src_points() const { return src_points_; }
+
+    std::vector<Eigen::Vector3f> get_tar_points() const { return tar_points_; }
+
     Eigen::Matrix4f get_global_pose() const { return global_pose_; }
 
     int get_best_score() const { return best_score_; }

--- a/bbs3d/src/gpu_bbs3d/bbs3d.cu
+++ b/bbs3d/src/gpu_bbs3d/bbs3d.cu
@@ -26,7 +26,8 @@ void BBS3D::set_tar_points(const std::vector<Eigen::Vector3f>& points, float min
   voxelmaps_ptr_->set_max_level(max_level);
   voxelmaps_ptr_->create_voxelmaps(points, stream);
 
-  calc_trans_search_range();
+  // Detect translation range from target points
+  set_trans_search_range(points);
 }
 
 void BBS3D::set_src_points(const std::vector<Eigen::Vector3f>& points) {
@@ -47,8 +48,8 @@ void BBS3D::set_src_points(const std::vector<Eigen::Vector3f>& points) {
     stream);
 }
 
-void BBS3D::calc_trans_search_range() {
-  // Detect translation range from target points
+void BBS3D::set_trans_search_range(const std::vector<Eigen::Vector3f>& points) {
+  // The minimum and maximum x, y, z values are selected from the 3D coordinate vector.
   Eigen::Vector3f min_xyz = Eigen::Vector3f::Constant(std::numeric_limits<float>::max());
   Eigen::Vector3f max_xyz = Eigen::Vector3f::Constant(std::numeric_limits<float>::lowest());
 
@@ -64,7 +65,7 @@ void BBS3D::calc_trans_search_range() {
   init_tz_range_ = std::make_pair<int, int>(std::floor(min_xyz.z() / top_res), std::ceil(max_xyz.z() / top_res));
 }
 
-void BBS3D::calc_angluar_search_range(std::vector<AngularInfo>& ang_info_vec) {
+void BBS3D::calc_angluar_info(std::vector<AngularInfo>& ang_info_vec) {
   float max_norm = src_points_[0].norm();
   for (const auto& point : src_points_) {
     float norm = point.norm();
@@ -154,7 +155,7 @@ void BBS3D::localize() {
   // Preapre initial transset
   const int max_level = voxelmaps_ptr_->get_max_level();
   std::vector<AngularInfo> ang_info_vec(max_level + 1);
-  calc_angluar_search_range(ang_info_vec);
+  calc_angluar_info(ang_info_vec);
   const auto init_transset = create_init_transset(ang_info_vec[max_level]);
 
   // Calc initial transset scores

--- a/test/src/gpu_bbs3d/gpu_test.cu
+++ b/test/src/gpu_bbs3d/gpu_test.cu
@@ -45,7 +45,7 @@ int BBS3DTest::run(std::string config) {
   // ====3D-BBS====
   // Set target points
   auto initi_t1 = std::chrono::high_resolution_clock::now();
-  std::cout << "[Voxel map] creating hierarchical voxel map..." << std::endl;
+  std::cout << "[Voxel map] Creating hierarchical voxel map..." << std::endl;
   std::unique_ptr<gpu::BBS3D> bbs3d_ptr(new gpu::BBS3D);
   bbs3d_ptr->set_tar_points(tar_points, min_level_res, max_level);
   bbs3d_ptr->set_angular_search_range(min_rpy.cast<float>(), max_rpy.cast<float>());


### PR DESCRIPTION
User can optionally set trans search range.
At least two points are needed to detect the trans search range.