### PR TITLE
add submodule eigen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/Eigen"]
+	path = thirdparty/Eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(bbs3d)
 
-find_package(Eigen3 REQUIRED)
-
 find_package(OpenMP)
 if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -18,7 +16,7 @@ endif()
 
 # Common include directories
 include_directories(
-  ${EIGEN3_INCLUDE_DIR}
+  thirdparty/Eigen
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bbs3d/include>
   $<INSTALL_INTERFACE:include>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,25 @@
 cmake_minimum_required(VERSION 3.5)
 project(bbs3d)
 
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+## find thirdparty/Eigen or Eigen3 package
+option(USE_THIRDPARTY_EIGEN "Include thirdparty eigen" OFF)
+file(GLOB entries "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/Eigen*")
+list(LENGTH entries num_entries)
+if(num_entries EQUAL 0)
+  set(thirdparty_empty ON)
+else()
+  set(thirdparty_empty OFF)
+  find_package(Eigen3 REQUIRED)
 endif()
 
+## find OpenMP
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
+## find CUDA
 option(BUILD_CUDA "Build GPU ver" ON)
 if (BUILD_CUDA)
   find_package(CUDA REQUIRED)
@@ -15,8 +28,14 @@ if (BUILD_CUDA)
 endif()
 
 # Common include directories
+if(USE_THIRDPARTY_EIGEN)
+  include_directories(thirdparty/Eigen)
+else()
+  include_directories(${EIGEN3_INCLUDE_DIR})
+endif()
+
 include_directories(
-  thirdparty/Eigen
+  ${CMAKE_CURRENT_SOURCE_DIR}/bbs3d/include
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bbs3d/include>
   $<INSTALL_INTERFACE:include>
 )

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ Specifically, when tested in a real environment with the following hardware conf
   - Paper: 9,272 ms on average
   - **Latest**: 3,494 ms on average
   - **Use saved voxelmap**: 130 ms on average
-- Localize
+- Global localization
   - Paper: 878 ms on average
   - **Latest**: **189 ms** on average  
 
 ## Dependencies
 - bbs3d (Lower versions are not tested)
   - CMake
+  - Eigen3 (3.4.0 or higher)
   - OpenMP
   - CUDA (12.0 or higher)
 - test
@@ -34,10 +35,12 @@ For more information, you can check [docker_start.md](./docker/docker_start.md)
 ## 3d_bbs core source code
 ### Build and Install
 ```shell script
-git clone https://github.com/KOKIAOKI/3d_bbs.git --recursive
+git clone https://github.com/KOKIAOKI/3d_bbs.git
 cd 3d_bbs
 mkdir build && cd build
 ```
+
+Note: If you are using Eigen3 below 3.4.0, git clone with ``--recursive``
 
 - CPU ver. & GPU ver. (Please ignore the large number of warnings)
 ```shell script

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Please refer to our [paper](https://arxiv.org/abs/2310.10023).
 
 <img alt="overview" src="figs/overview.jpg" width="50%">
 
-
 The latest implementation demonstrates faster processing times than those published in the paper.  
 Specifically, when tested in a real environment with the following hardware configuration (Intel Core i7-10700K 3.8GHz, 32GB RAM, and NVIDIA GeForce RTX2060), the processing times are as follows: 
 - Hierarchical voxelmap construction
@@ -17,9 +16,9 @@ Specifically, when tested in a real environment with the following hardware conf
 
 ## Dependencies
 - bbs3d (Lower versions are not tested)
-  - Eigen3 version 3.4.0 or higher
-  - CMake version 3.15 or higher
-  - GPU version: CUDA version 12.0 or higher
+  - CMake
+  - OpenMP
+  - CUDA (12.0 or higher)
 - test
   - (All bbs3d dependencies)
   - PCL
@@ -35,7 +34,7 @@ For more information, you can check [docker_start.md](./docker/docker_start.md)
 ## 3d_bbs core source code
 ### Build and Install
 ```shell script
-git clone https://github.com/KOKIAOKI/3d_bbs.git
+git clone https://github.com/KOKIAOKI/3d_bbs.git --recursive
 cd 3d_bbs
 mkdir build && cd build
 ```
@@ -43,14 +42,14 @@ mkdir build && cd build
 - CPU ver. & GPU ver. (Please ignore the large number of warnings)
 ```shell script
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j8
+make -j
 sudo make install
 ```
 
 - CPU ver. only
 ```shell script
 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_CUDA=OFF
-make -j8
+make -j
 sudo make install
 ```
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,6 @@ project(test)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 option(BUILD_CUDA "Build GPU ver" ON)
 
-find_package(PCL REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(cpu_bbs3d REQUIRED)
 find_package(OpenMP)
 
@@ -21,10 +19,12 @@ if (BUILD_CUDA)
   link_directories(${CUDA_LIBRARY_DIRS})
 endif()
 
+
 # Common include directories
+find_package(PCL REQUIRED)
 include_directories(
   ${PROJECT_SOURCE_DIR}/include
-  ${EIGEN3_INCLUDE_DIR}
+  ${PCL_INCLUDE_DIRS}
 )
 
 # Common libraries

--- a/test/test_code.md
+++ b/test/test_code.md
@@ -14,13 +14,13 @@ mkdir build && cd build
 - CPU ver. & GPU ver.
 ```shell script
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j8
+make -j
 ```
 
 - CPU ver. only  
 ```shell script
 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_CUDA=OFF
-make -j8
+make -j
 ```
 
 ### 2. Download
@@ -48,7 +48,7 @@ cd 3d_bbs/test/build/
 ./cpu_test <config_file_path>
 ```
 
-## 5. (Optional) Load voxelmap coordinates directly
+### 5. (Optional) Load voxelmap coordinates directly
 You can save the voxelmaps coordinates and skip 3D-BBS voxel construction if you reuse the same parameters of `min_level_res` and `max_level`.
 ```
 cd 3d_bbs/test/build/
@@ -56,6 +56,22 @@ cd 3d_bbs/test/build/
 ```
 Then, try again 4.Run. Voxelmaps coordinates in 'voxelmaps_coords' are automatically loaded.  
 Note: Test code preferentially uses the parameters in the generated text file 'voxel_params.txt'.
+
+## Use bbs3d in your cmake project
+1. Copy `test/cmake` to your project
+1. Copy description above `# Common include directories` in `test/CMakeLists.txt` to `your CMakeLists.txt`
+1. Add either of the following depending on your implementation. If you are using the CPU version, replace `gpu` with `cpu`.
+- If using PCL:
+```
+find_package(PCL REQUIRED)
+target_include_directories(yours ${PCL_INCLUDE_DIRS})
+target_link_libraries(yours ${PCL_LIBRARIES} ${gpu_bbs3d_LIBRARY})
+```
+- Otherwise:
+```
+find_package(Eigen3 REQUIRED)
+target_include_directories(yours ${EIGEN3_INCLUDE_DIR} ${gpu_bbs3d_LIBRARY})
+```
 
 ## Using your own 3D point cloud map and LiDAR scan data
 ### Convert ros2 bag to pcd file


### PR DESCRIPTION
Because eigen3.3.X has bug in the matrix calculation on CUDA kernel, I added eigen3.4.X in thirdparty/Eigen as submodule.
This is optional.