### PR TITLE
[fix] fix integer cast timing for get_best_score_percentage

### DIFF
--- a/bbs3d/include/cpu_bbs3d/bbs3d.hpp
+++ b/bbs3d/include/cpu_bbs3d/bbs3d.hpp
@@ -71,7 +71,7 @@ public:
     if (src_points_.size() == 0)
       return 0.0;
     else
-      return static_cast<double>(best_score_ / src_points_.size());
+      return static_cast<double>(best_score_) / src_points_.size();
   };
 
   bool has_timed_out() { return has_timed_out_; }

--- a/bbs3d/include/gpu_bbs3d/bbs3d.cuh
+++ b/bbs3d/include/gpu_bbs3d/bbs3d.cuh
@@ -75,7 +75,7 @@ public:
     if (src_points_.size() == 0)
       return 0.0f;
     else
-      return static_cast<float>(best_score_ / src_points_.size());
+      return static_cast<float>(best_score_) / src_points_.size();
   };
 
   bool has_timed_out() { return has_timed_out_; }


### PR DESCRIPTION
# Description

This PR fixes a bug where the casting timing in integer division was incorrect, causing unintended rounding to an integer. The casting has been adjusted to ensure the division result retains its fractional precision.

# How to test

After running global localization, call the `get_best_score_percentage()` function and confirm that the function returns the correct non-zero floating-point value instead of zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved score percentage calculations to prevent rounding errors, ensuring more accurate results in performance percentages across different computational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->