### PR TITLE
Fix boost dependency

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ option(BUILD_CUDA "Build GPU ver" ON)
 
 find_package(cpu_bbs3d REQUIRED)
 find_package(OpenMP)
+find_package(Boost REQUIRED COMPONENTS filesystem system)
 
 if (OpenMP_FOUND)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")


### PR DESCRIPTION
Hi, on ubuntu 24.04, I am unable to compile the cpu 3d bbs test,
```
usr/bin/ld: CMakeFiles/saver.dir/src/voxelmaps_saver.cpp.o: in function `pciof::load_pcd_file_paths(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
voxelmaps_saver.cpp:(.text+0x3ff5): undefined reference to `boost::filesystem::detail::status(boost::filesystem::path const&, boost::system::error_code*)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x410a): undefined reference to `boost::filesystem::detail::directory_iterator_construct(boost::filesystem::directory_iterator&, boost::filesystem::path const&, unsigned int, boost::filesystem::detail::directory_iterator_params*, boost::system::error_code*)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x417f): undefined reference to `boost::filesystem::detail::path_algorithms::extension_v3(boost::filesystem::path const&)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x423e): undefined reference to `boost::filesystem::detail::directory_iterator_increment(boost::filesystem::directory_iterator&, boost::system::error_code*)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x4266): undefined reference to `boost::filesystem::detail::dir_itr_imp::~dir_itr_imp()'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x426e): undefined reference to `boost::filesystem::detail::dir_itr_imp::operator delete(void*)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x4398): undefined reference to `boost::filesystem::detail::dir_itr_imp::~dir_itr_imp()'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x43a0): undefined reference to `boost::filesystem::detail::dir_itr_imp::operator delete(void*)'
/usr/bin/ld: voxelmaps_saver.cpp:(.text+0x4416): undefined reference to `boost::filesystem::detail::path_algorithms::stem_v3(boost::filesystem::path const&)'
/usr/bin/ld: CMakeFiles/saver.dir/src/voxelmaps_saver.cpp.o: in function `void boost::sp_adl_block::intrusive_ptr_release<boost::filesystem::detail::dir_itr_imp, boost::sp_adl_block:
```
this pr solves the problem