### PR TITLE
Optimize  hash lookup by breaking early on empty buckets for cpu bbs3d

### DIFF
--- a/bbs3d/src/cpu_bbs3d/bbs3d.cpp
+++ b/bbs3d/src/cpu_bbs3d/bbs3d.cpp
@@ -153,14 +153,16 @@ void BBS3D::calc_score(
       const std::uint32_t bucket_index = (hash + j) % num_buckets;
       const Eigen::Vector4i& bucket = buckets[bucket_index];
 
+      if (bucket.w() == 0) {
+        break;
+      }
+      
       if (bucket.x() != coord.x() || bucket.y() != coord.y() || bucket.z() != coord.z()) {
         continue;
       }
 
-      if (bucket.w() == 1) {
-        trans.score++;
-        break;
-      }
+      trans.score++;
+      break;
     }
   }
 }


### PR DESCRIPTION
Previously, the bbs3d would always scan up to max_bucket_scan_count buckets for each point, even if it encountered an empty bucket earlier. This is inefficient because in linear probing hash tables, an empty bucket indicates that no further matches can exist for the current hash value - the bucket would have been filled when the data was inserted.

The optimization checks for empty buckets (w == 0) during the probing sequence and breaks out of the loop immediately, avoiding unnecessary iterations. This significantly reduces the average number of probes required per lookup, especially when the hash table is not fully loaded.